### PR TITLE
Navbar/drawer fixes: gate notes on disable; single tool shown directly

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -35,8 +35,11 @@ class helper {
     public static function render_drawer(): string {
         global $OUTPUT, $PAGE;
 
+        $tools = \local_learningtools_get_drawer_tools();
+        // The note editor only belongs in the drawer when the note tool is enabled and permitted.
+        $shownotes = isset($tools['note']);
         $toolbuttons = '';
-        foreach (\local_learningtools_get_drawer_tools() as $shortname => $toolobj) {
+        foreach ($tools as $shortname => $toolobj) {
             // Notes are shown expanded in their own region, not as a button.
             if ($shortname === 'note') {
                 continue;
@@ -50,6 +53,7 @@ class helper {
             'contextid' => $PAGE->context->id,
             'toolbuttons' => $toolbuttons,
             'hastools' => $toolbuttons !== '',
+            'shownotes' => $shownotes,
             'autosave' => (bool) get_config('local_learningtools', 'autosavenotes'),
         ]);
     }

--- a/lib.php
+++ b/lib.php
@@ -103,7 +103,8 @@ function local_learningtools_extend_settings_navigation($settingnav, $context) {
 
     // Render the drawer now (while the page header can still receive header actions) so tools
     // such as focus can register their <link> stylesheet in time. The hook outputs it later.
-    if (local_learningtools_is_drawer_mode()) {
+    // A single available tool is shown directly in the navbar, so no drawer is needed then.
+    if (local_learningtools_is_drawer_mode() && count(local_learningtools_get_drawer_tools()) > 1) {
         \local_learningtools\hook_callbacks::$drawerhtml = \local_learningtools\helper::render_drawer();
     }
 }
@@ -422,6 +423,15 @@ function local_learningtools_get_drawer_tools() {
 function local_learningtools_render_navbar_output(\renderer_base $renderer) {
     if (!local_learningtools_drawer_should_show()) {
         return '';
+    }
+    // When only one tool is available, show that tool directly (like the floating button does)
+    // instead of the generic drawer launcher - the drawer is not used.
+    $tools = local_learningtools_get_drawer_tools();
+    if (count($tools) === 1) {
+        $tool = reset($tools);
+        return $renderer->render_from_template('local_learningtools/navbar_single', [
+            'tool' => $tool->render_template(),
+        ]);
     }
     return $renderer->render_from_template('local_learningtools/navbar_icon', [
         'icon' => 'fa fa-magic',

--- a/styles.css
+++ b/styles.css
@@ -396,3 +396,36 @@ body:has(.learningtools-action-info:not(.floating-button-left)) #page-footer .bt
     align-items: center;
     gap: 15px;
 }
+
+/* Single-tool navbar launcher: render the one available tool as a compact navbar icon. */
+.learningtools-navbar-single {
+    display: inline-flex;
+    align-items: center;
+}
+
+.learningtools-navbar-single [class$="info"] {
+    position: relative;
+    margin: 0;
+}
+
+.learningtools-navbar-single [class$="info"] > button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    box-shadow: none;
+    cursor: pointer;
+}
+
+.learningtools-navbar-single [class$="info"] > button i {
+    font-size: 1.1rem;
+}
+
+/* The floating-button hover labels are not used in the navbar. */
+.learningtools-navbar-single [class$="info"] > p {
+    display: none;
+}

--- a/templates/drawer.mustache
+++ b/templates/drawer.mustache
@@ -24,7 +24,9 @@
     {
         "contextid": 1,
         "toolbuttons": "<div class=\"ltbookmarksinfo\"></div>",
-        "hastools": true
+        "hastools": true,
+        "shownotes": true,
+        "autosave": false
     }
 }}
 {{< core/drawer}}
@@ -50,6 +52,7 @@
                     {{{toolbuttons}}}
                 </div>
             {{/hastools}}
+            {{#shownotes}}
             <div class="lt-drawer-notes px-2" data-region="lt-drawer-notes" data-contextid="{{contextid}}">
                 <div class="lt-drawer-notes-loading text-center p-3" data-region="lt-drawer-notes-loading">
                     {{#pix}}i/loading, core{{/pix}}
@@ -62,6 +65,7 @@
                 </button>
             </div>
             {{/autosave}}
+            {{/shownotes}}
         </div>
     {{/drawercontent}}
 {{/ core/drawer}}

--- a/templates/navbar_single.mustache
+++ b/templates/navbar_single.mustache
@@ -1,0 +1,30 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template local_learningtools/navbar_single
+
+    Navbar launcher used when only one Learning Tool is available: the tool renders itself
+    directly (its own button + behaviour), so the drawer is not used.
+
+    Example context (json):
+    {
+        "tool": "<div class=\"ltbookmarksinfo\"><button id=\"ltbookmarks-action\"></button></div>"
+    }
+}}
+<div class="popover-region learningtools-navbar learningtools-navbar-single" data-region="learningtools-navbar">
+    {{{tool}}}
+</div>

--- a/tests/buttonposition_test.php
+++ b/tests/buttonposition_test.php
@@ -213,4 +213,41 @@ final class buttonposition_test extends \advanced_testcase {
         $this->assertStringNotContainsString('data-region="lt-drawer-notes"', $html);
         $this->assertStringNotContainsString('lt-drawer-save-note', $html);
     }
+
+    /**
+     * With several tools available the navbar shows the generic drawer toggle.
+     *
+     * @covers ::local_learningtools_render_navbar_output
+     */
+    public function test_navbar_multiple_tools_render_the_drawer_toggle(): void {
+        global $PAGE;
+        set_config('buttonposition', 'drawer', 'local_learningtools');
+        $this->setAdminUser();
+        $PAGE->set_context(\context_system::instance());
+        $PAGE->set_url('/');
+
+        $output = local_learningtools_render_navbar_output($PAGE->get_renderer('core'));
+        $this->assertStringContainsString('learningtools-drawer-toggle', $output);
+    }
+
+    /**
+     * With only one tool available the navbar renders that tool directly, not the drawer toggle.
+     *
+     * @covers ::local_learningtools_render_navbar_output
+     */
+    public function test_navbar_single_tool_renders_the_tool_directly(): void {
+        global $PAGE, $DB;
+        set_config('buttonposition', 'drawer', 'local_learningtools');
+        $this->setAdminUser();
+        $PAGE->set_context(\context_system::instance());
+        $PAGE->set_url('/');
+
+        // Leave only the bookmarks tool enabled.
+        $DB->set_field_select('local_learningtools_products', 'status', 0, 'shortname <> ?', ['bookmarks']);
+
+        $output = local_learningtools_render_navbar_output($PAGE->get_renderer('core'));
+        $this->assertStringContainsString('learningtools-navbar-single', $output);
+        $this->assertStringContainsString('ltbookmarks', $output);
+        $this->assertStringNotContainsString('learningtools-drawer-toggle', $output);
+    }
 }

--- a/tests/buttonposition_test.php
+++ b/tests/buttonposition_test.php
@@ -191,4 +191,26 @@ final class buttonposition_test extends \advanced_testcase {
         set_config('autosavenotes', 1, 'local_learningtools');
         $this->assertStringNotContainsString('lt-drawer-save-note', helper::render_drawer());
     }
+
+    /**
+     * Disabling the note tool removes the note editor region (and its save button) from the drawer.
+     *
+     * @covers \local_learningtools\helper::render_drawer
+     */
+    public function test_render_drawer_hides_notes_when_note_tool_disabled(): void {
+        global $PAGE, $DB;
+        set_config('buttonposition', 'drawer', 'local_learningtools');
+        $this->setAdminUser();
+        $PAGE->set_context(\context_system::instance());
+        $PAGE->set_url('/');
+
+        // The editor region is present while the note tool is enabled.
+        $this->assertStringContainsString('data-region="lt-drawer-notes"', helper::render_drawer());
+
+        // Disable the note tool: its editor region and save button disappear from the drawer.
+        $DB->set_field('local_learningtools_products', 'status', 0, ['shortname' => 'note']);
+        $html = helper::render_drawer();
+        $this->assertStringNotContainsString('data-region="lt-drawer-notes"', $html);
+        $this->assertStringNotContainsString('lt-drawer-save-note', $html);
+    }
 }


### PR DESCRIPTION
Two pre-release fixes to the navbar (drawer) launcher mode.

## 1. Notes editor ignored the note tool being disabled
In navbar mode the drawer always rendered the note editor region, even when the **note** tool was disabled (or the user lacked the capability). `helper::render_drawer()` now passes a `shownotes` flag (true only when `note` is in `local_learningtools_get_drawer_tools()`), and the template gates the editor region + its save button on it. The drawer JS already no-ops when the region is absent.

## 2. A single available tool is now shown directly in the navbar
The floating button already collapses to the one tool when only one is available; the navbar did the same conceptually but still showed the generic "magic" drawer toggle. Now, when exactly one tool is available, `local_learningtools_render_navbar_output()` renders **that tool directly** (its own button + behaviour) and the drawer isn't rendered at all — e.g. bookmarks shows the bookmark icon and toggles in place; notes shows the note icon and opens its editor. Reuses each tool's existing `render_template()` + JS (which bind by selector), plus compact navbar styling.

## Testing
- PHPUnit `buttonposition_test` 15/15, incl. notes-hidden-when-disabled, single-tool-renders-tool, multiple-tools-render-toggle.
- phpcs / stylelint clean; templates parse (vnu HTML check runs in CI).

## Note for review
Functionally verified for the launcher-style tools (bookmarks, notes, report, focus, schedule). The **like** tool's reaction flyout is floating-button-scoped, so as a lone navbar tool its reactions render inline rather than as a flyout — worth an eyeball, but it stays usable. Recommend a quick visual pass on the live site for per-tool polish.